### PR TITLE
指定したユーザに関連するPRを状態別にマークダウンで表示する

### DIFF
--- a/bin/pr-tree
+++ b/bin/pr-tree
@@ -28,41 +28,21 @@ def main
   puts git_config.repo
 
   github_client = GitHubClient.new(git_config)
-  branches, pulls = *Concurrent::Promise.zip(
-    Concurrent::Promise.execute { github_client.branches },
-    Concurrent::Promise.execute { github_client.pull_requests }
-  ).value
 
-  prs = pulls.map do |pr|
-    base_branch = branches.find{|b| b['name'] == pr['base']['ref']}
-    PrItem.new({
-      number: pr['number'],
-      title: pr['title'],
-      user: pr['user']['login'],
-      reviewers: pr['requested_reviewers'].map{|r| r['login']},
-      base: pr['base']['ref'],
-      is_latest: base_branch.nil? ? true : pr['base']['sha'] == base_branch['commit']['sha'],
-      head: pr['head']['ref'],
-      url: pr['html_url'],
-      status: pr['status'],
-      current_branch: pr['head']['ref'] == git_config.branch
-    })
-  end
+  pr_builder = PrBuilder.new(github_client, git_config.branch)
+    .filter_keyword!(@keyword)
+    .filter_reviewer!(@reviewer)
 
-  prs = prs.select {|pr| pr.user_like(@keyword) }
-  prs = prs.select {|pr| pr.reviewer_like(@reviewer) }
-
-
-  builder = nil
-  if @markdown
-    builder= MarkdownBuilder.new(prs)
-  else
-    builder = TreeBuilder.new(prs)
-    builder.add_top_item {|key| PrItem.new({
-      head: key,
-      current_branch: key == git_config.branch
-    }) }
-  end
+  builder = if @markdown
+              MarkdownBuilder.new(pr_builder.prs)
+            else
+              builder = TreeBuilder.new(pr_builder.prs)
+              builder.add_top_item {|key| PrItem.new({
+                head: key,
+                current_branch: key == git_config.branch
+              }) }
+              builder
+            end
 
   builder.show
 end
@@ -157,6 +137,43 @@ class GitHubClient
 
   def base_uri
     "https://api.github.com/repos/#{owner}/#{repo}"
+  end
+end
+
+class PrBuilder
+  attr_reader :prs
+
+  def initialize(github_client, current_branch)
+    branches, pulls = *Concurrent::Promise.zip(
+      Concurrent::Promise.execute { github_client.branches },
+      Concurrent::Promise.execute { github_client.pull_requests }
+    ).value
+
+    @prs = pulls.map do |pr|
+      base_branch = branches.find{|b| b['name'] == pr['base']['ref']}
+      PrItem.new({
+        number: pr['number'],
+        title: pr['title'],
+        user: pr['user']['login'],
+        reviewers: pr['requested_reviewers'].map{|r| r['login']},
+        base: pr['base']['ref'],
+        is_latest: base_branch.nil? ? true : pr['base']['sha'] == base_branch['commit']['sha'],
+        head: pr['head']['ref'],
+        url: pr['html_url'],
+        status: pr['status'],
+        current_branch: pr['head']['ref'] == current_branch
+      })
+    end
+  end
+
+  def filter_keyword!(keyword)
+    @prs = @prs.select {|pr| pr.user_like(keyword) }
+    self
+  end
+
+  def filter_reviewer!(reviewer)
+    @prs = @prs.select {|pr| pr.reviewer_like(reviewer) }
+    self
   end
 end
 

--- a/bin/pr-tree
+++ b/bin/pr-tree
@@ -317,6 +317,8 @@ class StatusBuilder < MarkdownBuilder
   private
 
   def show_as_markdown
+    return if @items.empty?
+
     puts Color.black('#### Assigned for review')
     @items.select{ |pr| pr.reviewer_like?(@user)}.each do |item|
       print_item(item)

--- a/bin/pr-tree
+++ b/bin/pr-tree
@@ -12,6 +12,7 @@ def main
   opt.on('-r', '--reviewer REVIEWER', 'filter by reviewer') { |v| @reviewer = v }
   opt.on('-u', '--url GIT_URL', 'specific git url') { |v| @url = v }
   opt.on('-m', '--markdown', 'show as markdown') { |v| @markdown = true }
+  opt.on('-s', '--status USER', 'show as markdown with user status') { |v| @status = v }
   opt.parse(ARGV)
 
   git_config = GitConfig.new(@url)
@@ -31,17 +32,19 @@ def main
 
   pr_builder = PrBuilder.new(github_client, git_config.branch)
     .filter_keyword!(@keyword)
+    .filter_keyword!(@status)
     .filter_reviewer!(@reviewer)
 
   builder = if @markdown
               MarkdownBuilder.new(pr_builder.prs)
+            elsif @status
+              StatusBuilder.new(pr_builder.prs, @status)
             else
-              builder = TreeBuilder.new(pr_builder.prs)
-              builder.add_top_item {|key| PrItem.new({
+              TreeBuilder.new(pr_builder.prs)
+                .add_top_item {|key| PrItem.new({
                 head: key,
                 current_branch: key == git_config.branch
               }) }
-              builder
             end
 
   builder.show
@@ -167,12 +170,12 @@ class PrBuilder
   end
 
   def filter_keyword!(keyword)
-    @prs = @prs.select {|pr| pr.user_like(keyword) }
+    @prs = @prs.select {|pr| pr.user_like?(keyword) }
     self
   end
 
   def filter_reviewer!(reviewer)
-    @prs = @prs.select {|pr| pr.reviewer_like(reviewer) }
+    @prs = @prs.select {|pr| pr.reviewer_like?(reviewer) }
     self
   end
 end
@@ -211,6 +214,7 @@ class TreeBuilder
       top_item.children = item[1]
       top_item
     end
+    self
   end
 
   def show
@@ -304,6 +308,32 @@ class MarkdownBuilder
   end
 end
 
+class StatusBuilder < MarkdownBuilder
+  def initialize(items, user)
+    super(items)
+    @user = user
+  end
+
+  private
+
+  def show_as_markdown
+    puts Color.black('#### Assigned for review')
+    @items.select{ |pr| pr.reviewer_like?(@user)}.each do |item|
+      print_item(item)
+    end
+
+    puts Color.black('#### Requested for review')
+    @items.select{ |pr| pr.requested_review?(@user)}.each do |item|
+      print_item(item)
+    end
+
+    puts Color.black('#### Work in progress')
+    @items.select{ |pr| pr.user_wip?(@user)}.each do |item|
+      print_item(item)
+    end
+  end
+end
+
 class Color
   def self.g(t)
     "\e[32m" + t + Color.end_code
@@ -375,12 +405,22 @@ class PrItem
     end
   end
 
-  def user_like(keyword)
+  def user_like?(keyword)
     return true if keyword.nil?
     (@params[:reviewers] | [@params[:user]]).any? {|u| u.include?(keyword) }
   end
 
-  def reviewer_like(keyword)
+  def user_wip?(keyword)
+    return true if keyword.nil?
+    @params[:user].include?(keyword) && @params[:reviewers].empty?
+  end
+
+  def requested_review?(keyword)
+    return true if keyword.nil?
+    @params[:user].include?(keyword) && @params[:reviewers].any?
+  end
+
+  def reviewer_like?(keyword)
     return true if keyword.nil?
     @params[:reviewers].any? {|u| u.include?(keyword) }
   end


### PR DESCRIPTION
自分に関わるPRがどの状態(レビュー依頼され中、レビュー依頼中、作業中) なのかぱっと判別したい。

表示イメージ
```
$ pr-tree -s volpe28v

#### Assigned for review
- [ ] *[example-base2] > volpe28v
    - o Sample pull request base No2 #5
    -  hoge https://github.com/volpe28v/pr-tree/pull/5
#### Requested for a review
- [ ]  [example2-1] > hoge
    - o Sample pull request No2-1 #4
    -  volpe28v https://github.com/volpe28v/pr-tree/pull/4
#### Work in progress
- [ ]  [example2]
    - o Sample pull request No2 #3
    -  volpe28v https://github.com/volpe28v/pr-tree/pull/3
- [ ]  [example1]
    - o Sample pull request No1 #2
    -  volpe28v https://github.com/volpe28v/pr-tree/pull/2
```


- [x] 下準備のリファクタ
- [x] -s オプションで上記表示を実現
